### PR TITLE
Fixes github link for mint

### DIFF
--- a/_posts/2015-03-11-mint.md
+++ b/_posts/2015-03-11-mint.md
@@ -8,5 +8,5 @@ Mint is STUPS’ secret distributor and rotator.
 
 Its main task is to constantly rotate service passwords or API keys and provide the secrets to the actual applications.
 
-* [View on Github](https://github.com/zalando-stups/mint)
+* [View on Github](https://github.com/zalando-stups/mint-worker) 
 * [Read documention on Read the Docs](//docs.stups.io/en/latest/components/mint.html)


### PR DESCRIPTION
Link to github sources was broken.

Not sure which link is best but I chose mint-worker over mint-storage.
