### PR TITLE
Fix link to Twintip repository

### DIFF
--- a/_posts/2015-03-11-twintip.md
+++ b/_posts/2015-03-11-twintip.md
@@ -8,5 +8,5 @@ TWINTIP is STUPS’ API crawler.
 
 TWINTIP collects API definition of all applications that are registered in Kio.
 
-* [View on Github](https://github.com/zalando-stups/twintip)
+* [View on Github](https://github.com/zalando-stups/twintip-crawler)
 * [Read documention on Read the Docs](//docs.stups.io/en/latest/components/twintip.html)


### PR DESCRIPTION
This pull request fixes the link to twintip crawler repository on Github.
